### PR TITLE
fix: 로그아웃 리다이렉트 URL 프록시 환경 대응

### DIFF
--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -14,7 +14,14 @@ import { LOGIN_PATH } from '@/constants/routes';
  * HTML form의 action으로 직접 호출 가능 (JavaScript hydration 불필요)
  */
 export async function POST(request: NextRequest) {
-  const response = NextResponse.redirect(new URL(LOGIN_PATH, request.url), {
+  // 프록시/로드밸런서 환경에서 올바른 origin 결정
+  const origin =
+    process.env.NEXT_PUBLIC_APP_URL ||
+    request.headers.get('x-forwarded-host')
+      ? `https://${request.headers.get('x-forwarded-host')}`
+      : request.url;
+
+  const response = NextResponse.redirect(new URL(LOGIN_PATH, origin), {
     status: 302,
   });
 


### PR DESCRIPTION
Render 등 프록시/로드밸런서 환경에서 request.url이 내부 주소
(localhost:10000)를 반환하는 문제 수정

- NEXT_PUBLIC_APP_URL 환경 변수 우선 사용
- x-forwarded-host 헤더 fallback 지원

🤖 Generated with [Claude Code](https://claude.com/claude-code)