### PR TITLE
fix: 로그아웃 리다이렉트 연산자 우선순위 버그 수정

### DIFF
--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -15,11 +15,10 @@ import { LOGIN_PATH } from '@/constants/routes';
  */
 export async function POST(request: NextRequest) {
   // 프록시/로드밸런서 환경에서 올바른 origin 결정
+  const forwardedHost = request.headers.get('x-forwarded-host');
   const origin =
     process.env.NEXT_PUBLIC_APP_URL ||
-    request.headers.get('x-forwarded-host')
-      ? `https://${request.headers.get('x-forwarded-host')}`
-      : request.url;
+    (forwardedHost ? `https://${forwardedHost}` : new URL(request.url).origin);
 
   const response = NextResponse.redirect(new URL(LOGIN_PATH, origin), {
     status: 302,


### PR DESCRIPTION
삼항 연산자가 || 보다 우선순위가 낮아서 의도와 다르게 동작하는 문제 수정
- 변수 분리로 로직 명확화
- new URL().origin 사용으로 안전하게 origin 추출

🤖 Generated with [Claude Code](https://claude.com/claude-code)