### PR TITLE
fix: 모든 페이지 로딩 UI를 실제 페이지 구조와 일치하도록 업데이트

### DIFF
--- a/src/app/(dashboard)/admin/approvals/loading.tsx
+++ b/src/app/(dashboard)/admin/approvals/loading.tsx
@@ -1,8 +1,9 @@
 /**
  * 가입 승인 페이지 로딩 UI
+ * 카드 리스트 형태 (ApprovalTable)
  */
 import { Skeleton } from '@/components/ui/skeleton';
-import { Card, CardContent } from '@/components/ui/card';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
 
 export default function AdminApprovalsLoading(): React.ReactElement {
   return (
@@ -13,29 +14,40 @@ export default function AdminApprovalsLoading(): React.ReactElement {
         <Skeleton className="h-4 w-72" />
       </div>
 
-      {/* 테이블 카드 스켈레톤 */}
-      <Card>
-        <CardContent className="p-6">
-          {/* 테이블 헤더 */}
-          <div className="flex items-center gap-4 pb-4 border-b">
-            <Skeleton className="h-4 w-24" />
-            <Skeleton className="h-4 w-32" />
-            <Skeleton className="h-4 w-20" />
-            <Skeleton className="h-4 w-24" />
-            <Skeleton className="h-4 w-16" />
-          </div>
-          {/* 테이블 로우 */}
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="flex items-center gap-4 py-4 border-b last:border-0">
-              <Skeleton className="h-4 w-32" />
-              <Skeleton className="h-4 w-48" />
-              <Skeleton className="h-6 w-16 rounded-full" />
-              <Skeleton className="h-4 w-28" />
-              <Skeleton className="h-8 w-20 rounded" />
-            </div>
-          ))}
-        </CardContent>
-      </Card>
+      {/* 승인 대기 카드 리스트 */}
+      <div className="space-y-4">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <Card key={i}>
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <Skeleton className="h-10 w-10 rounded-full" />
+                  <div className="space-y-1">
+                    <Skeleton className="h-5 w-32" />
+                    <Skeleton className="h-4 w-48" />
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-6 w-16 rounded-full" />
+                  <Skeleton className="h-4 w-24" />
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="pt-0">
+              <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+                <div className="space-y-1">
+                  <Skeleton className="h-3 w-28" />
+                  <Skeleton className="h-3 w-32" />
+                </div>
+                <div className="flex gap-2">
+                  <Skeleton className="h-9 w-20" />
+                  <Skeleton className="h-9 w-20" />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/app/(dashboard)/admin/dashboard/loading.tsx
+++ b/src/app/(dashboard)/admin/dashboard/loading.tsx
@@ -1,5 +1,6 @@
 /**
  * 관리자 대시보드 로딩 UI
+ * 환영 카드 + 4개 통계 카드 + 2열 (승인대기 + 빠른메뉴) 레이아웃
  */
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
@@ -7,14 +8,22 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 export default function AdminDashboardLoading(): React.ReactElement {
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <Skeleton className="h-8 w-48" />
-        <Skeleton className="h-4 w-64" />
-      </div>
+      {/* 환영 메시지 카드 */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-4 w-64 mb-4" />
+          <div className="space-y-2">
+            <Skeleton className="h-3 w-40" />
+          </div>
+        </CardContent>
+      </Card>
 
-      {/* 통계 카드 */}
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        {Array.from({ length: 4 }).map((_, i) => (
+      {/* 통계 카드 - 4개 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        {[1, 2, 3, 4].map((i) => (
           <Card key={i}>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <Skeleton className="h-4 w-24" />
@@ -22,31 +31,53 @@ export default function AdminDashboardLoading(): React.ReactElement {
             </CardHeader>
             <CardContent>
               <Skeleton className="h-8 w-20" />
+              <Skeleton className="mt-1 h-3 w-32" />
             </CardContent>
           </Card>
         ))}
       </div>
 
-      {/* 승인 대기 목록 */}
-      <Card>
-        <CardHeader>
-          <Skeleton className="h-6 w-32" />
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="flex justify-between items-center p-4 border rounded">
-              <div className="space-y-2">
-                <Skeleton className="h-4 w-32" />
-                <Skeleton className="h-3 w-48" />
-              </div>
-              <div className="flex gap-2">
-                <Skeleton className="h-8 w-16" />
-                <Skeleton className="h-8 w-16" />
-              </div>
+      {/* 2열 레이아웃: 승인 대기 + 빠른 메뉴 */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* 최근 승인 대기 */}
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-2">
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="h-8 w-20" />
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="flex items-center justify-between p-3 rounded-lg bg-gray-50">
+                  <div className="flex items-center gap-3">
+                    <Skeleton className="h-8 w-8 rounded-full" />
+                    <div className="space-y-1">
+                      <Skeleton className="h-4 w-24" />
+                      <Skeleton className="h-3 w-32" />
+                    </div>
+                  </div>
+                  <div className="text-right space-y-1">
+                    <Skeleton className="h-5 w-16" />
+                    <Skeleton className="h-3 w-20" />
+                  </div>
+                </div>
+              ))}
             </div>
-          ))}
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+
+        {/* 빠른 메뉴 */}
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-5 w-24" />
+          </CardHeader>
+          <CardContent className="grid grid-cols-2 gap-3">
+            {[1, 2, 3, 4].map((i) => (
+              <Skeleton key={i} className="h-20 w-full rounded-lg" />
+            ))}
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }

--- a/src/app/(dashboard)/admin/history/loading.tsx
+++ b/src/app/(dashboard)/admin/history/loading.tsx
@@ -1,9 +1,9 @@
 /**
  * 관리자 이력 페이지 로딩 UI
- * 필터와 테이블 레이아웃 유지
+ * 필터 + 테이블(이벤트 요약) + 페이지네이션 레이아웃
  */
 import { Skeleton } from '@/components/ui/skeleton';
-import { Card, CardContent } from '@/components/ui/card';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
 
 export default function AdminHistoryLoading(): React.ReactElement {
   return (
@@ -11,47 +11,65 @@ export default function AdminHistoryLoading(): React.ReactElement {
       {/* 페이지 헤더 스켈레톤 */}
       <div className="space-y-2">
         <Skeleton className="h-8 w-32" />
-        <Skeleton className="h-4 w-56" />
+        <Skeleton className="h-4 w-96" />
       </div>
 
       {/* 필터 영역 스켈레톤 */}
       <Card>
-        <CardContent className="p-4">
-          <div className="flex flex-wrap gap-4">
-            <Skeleton className="h-10 w-40" />
-            <Skeleton className="h-10 w-40" />
-            <Skeleton className="h-10 w-40" />
-            <Skeleton className="h-10 w-40" />
-            <Skeleton className="h-10 w-24" />
+        <CardHeader className="pb-3">
+          <Skeleton className="h-5 w-16" />
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+          <div className="flex gap-2 mt-4">
+            <Skeleton className="h-9 w-20" />
+            <Skeleton className="h-9 w-20" />
           </div>
         </CardContent>
       </Card>
 
-      {/* 테이블 스켈레톤 */}
-      <Card>
-        <CardContent className="p-0">
-          <div className="border-b p-4">
-            <div className="flex gap-4">
-              {Array.from({ length: 7 }).map((_, i) => (
-                <Skeleton key={i} className="h-4 w-20" />
-              ))}
-            </div>
-          </div>
-          {Array.from({ length: 10 }).map((_, i) => (
-            <div key={i} className="border-b p-4">
-              <div className="flex gap-4">
-                {Array.from({ length: 7 }).map((_, j) => (
-                  <Skeleton key={j} className="h-4 w-20" />
-                ))}
+      {/* 이벤트 요약 카드 리스트 */}
+      <div className="space-y-4">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <Card key={i}>
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <Skeleton className="h-10 w-10 rounded-full" />
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <Skeleton className="h-5 w-16 rounded-full" />
+                      <Skeleton className="h-4 w-24" />
+                    </div>
+                    <Skeleton className="h-4 w-32" />
+                  </div>
+                </div>
+                <div className="text-right space-y-1">
+                  <Skeleton className="h-6 w-16 ml-auto" />
+                  <Skeleton className="h-4 w-12 ml-auto" />
+                </div>
               </div>
-            </div>
-          ))}
-        </CardContent>
-      </Card>
+            </CardHeader>
+            <CardContent className="pt-0">
+              <div className="flex items-center gap-2 p-2 bg-gray-50 rounded-lg">
+                <Skeleton className="h-4 w-4" />
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-4 w-4" />
+                <Skeleton className="h-4 w-28" />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
 
       {/* 페이지네이션 스켈레톤 */}
       <div className="flex justify-center gap-2">
-        {Array.from({ length: 5 }).map((_, i) => (
+        {[1, 2, 3, 4, 5].map((i) => (
           <Skeleton key={i} className="h-10 w-10" />
         ))}
       </div>

--- a/src/app/(dashboard)/admin/recalls/loading.tsx
+++ b/src/app/(dashboard)/admin/recalls/loading.tsx
@@ -1,8 +1,9 @@
 /**
  * 회수 모니터링 페이지 로딩 UI
+ * 필터 + 카드 리스트 형태
  */
 import { Skeleton } from '@/components/ui/skeleton';
-import { Card, CardContent } from '@/components/ui/card';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
 
 export default function AdminRecallsLoading(): React.ReactElement {
   return (
@@ -15,38 +16,61 @@ export default function AdminRecallsLoading(): React.ReactElement {
 
       {/* 필터 영역 스켈레톤 */}
       <Card>
-        <CardContent className="p-4">
+        <CardHeader className="pb-3">
+          <Skeleton className="h-5 w-16" />
+        </CardHeader>
+        <CardContent>
           <div className="flex flex-wrap gap-4">
             <Skeleton className="h-10 w-36" />
             <Skeleton className="h-10 w-36" />
             <Skeleton className="h-10 w-28" />
           </div>
+          <div className="flex gap-2 mt-4">
+            <Skeleton className="h-9 w-20" />
+            <Skeleton className="h-9 w-20" />
+          </div>
         </CardContent>
       </Card>
 
-      {/* 테이블 카드 스켈레톤 */}
-      <Card>
-        <CardContent className="p-6">
-          {/* 테이블 헤더 */}
-          <div className="flex items-center gap-4 pb-4 border-b">
-            <Skeleton className="h-4 w-20" />
-            <Skeleton className="h-4 w-24" />
-            <Skeleton className="h-4 w-32" />
-            <Skeleton className="h-4 w-16" />
-            <Skeleton className="h-4 w-28" />
-          </div>
-          {/* 테이블 로우 */}
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="flex items-center gap-4 py-4 border-b last:border-0">
-              <Skeleton className="h-6 w-16 rounded-full" />
-              <Skeleton className="h-4 w-32" />
-              <Skeleton className="h-4 w-40" />
-              <Skeleton className="h-4 w-12" />
-              <Skeleton className="h-4 w-28" />
-            </div>
-          ))}
-        </CardContent>
-      </Card>
+      {/* 회수 이력 카드 리스트 */}
+      <div className="space-y-4">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <Card key={i}>
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <Skeleton className="h-10 w-10 rounded-full" />
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <Skeleton className="h-5 w-20 rounded-full" />
+                      <Skeleton className="h-4 w-28" />
+                    </div>
+                    <Skeleton className="h-4 w-32" />
+                  </div>
+                </div>
+                <div className="text-right space-y-1">
+                  <Skeleton className="h-6 w-16 ml-auto" />
+                  <Skeleton className="h-4 w-24 ml-auto" />
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="pt-0">
+              {/* 회수 사유 */}
+              <div className="p-3 bg-amber-50 rounded-lg">
+                <Skeleton className="h-3 w-16 mb-1" />
+                <Skeleton className="h-4 w-full" />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* 페이지네이션 스켈레톤 */}
+      <div className="flex justify-center gap-2">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <Skeleton key={i} className="h-10 w-10" />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/app/(dashboard)/distributor/dashboard/loading.tsx
+++ b/src/app/(dashboard)/distributor/dashboard/loading.tsx
@@ -1,5 +1,6 @@
 /**
  * 유통사 대시보드 로딩 UI
+ * 환영 카드 + 3개 통계 카드 레이아웃
  */
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
@@ -7,13 +8,24 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 export default function DistributorDashboardLoading(): React.ReactElement {
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <Skeleton className="h-8 w-48" />
-        <Skeleton className="h-4 w-64" />
-      </div>
+      {/* 환영 메시지 카드 */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-4 w-64 mb-4" />
+          <div className="space-y-2">
+            <Skeleton className="h-3 w-48" />
+            <Skeleton className="h-3 w-40" />
+            <Skeleton className="h-3 w-36" />
+          </div>
+        </CardContent>
+      </Card>
 
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        {Array.from({ length: 4 }).map((_, i) => (
+      {/* 통계 카드 - 3개 (유통사) */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {[1, 2, 3].map((i) => (
           <Card key={i}>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <Skeleton className="h-4 w-24" />

--- a/src/app/(dashboard)/distributor/history/loading.tsx
+++ b/src/app/(dashboard)/distributor/history/loading.tsx
@@ -1,5 +1,6 @@
 /**
  * 유통사 거래 이력 페이지 로딩 UI
+ * 카드 리스트 형태 (TransactionHistoryTable)
  */
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
@@ -10,46 +11,55 @@ export default function HistoryLoading(): React.ReactElement {
       {/* 페이지 헤더 스켈레톤 */}
       <div className="space-y-2">
         <Skeleton className="h-8 w-32" />
-        <Skeleton className="h-4 w-72" />
+        <Skeleton className="h-4 w-96" />
       </div>
 
-      {/* 필터 영역 스켈레톤 */}
-      <div className="flex gap-4 flex-wrap">
-        <Skeleton className="h-10 w-32" />
-        <Skeleton className="h-10 w-40" />
-        <Skeleton className="h-10 w-36" />
+      {/* 거래 이력 카드 리스트 */}
+      <div className="space-y-4">
+        {[1, 2, 3, 4].map((i) => (
+          <Card key={i}>
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  {/* 액션 아이콘 */}
+                  <Skeleton className="h-10 w-10 rounded-full" />
+                  <div className="space-y-1">
+                    <Skeleton className="h-5 w-16 rounded-full" />
+                    <Skeleton className="h-4 w-32" />
+                  </div>
+                </div>
+                {/* 수량 */}
+                <div className="text-right space-y-1">
+                  <Skeleton className="h-6 w-16 ml-auto" />
+                  <Skeleton className="h-3 w-12 ml-auto" />
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="pt-0">
+              {/* 거래 당사자 표시 */}
+              <div className="flex items-center gap-2 mb-3 p-2 bg-gray-50 rounded-lg">
+                <Skeleton className="h-3 w-3" />
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-4 w-4" />
+                <Skeleton className="h-3 w-3" />
+                <Skeleton className="h-4 w-24" />
+              </div>
+              {/* 제품 목록 */}
+              <div className="space-y-2">
+                <div className="border rounded-lg p-3">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <Skeleton className="h-4 w-4" />
+                      <Skeleton className="h-4 w-32" />
+                    </div>
+                    <Skeleton className="h-5 w-12 rounded-full" />
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
       </div>
-
-      {/* 거래 이력 테이블 스켈레톤 */}
-      <Card>
-        <CardHeader>
-          <Skeleton className="h-6 w-28" />
-        </CardHeader>
-        <CardContent>
-          {/* 테이블 헤더 */}
-          <div className="border-b pb-3 mb-4">
-            <div className="grid grid-cols-6 gap-4">
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-4 w-24" />
-            </div>
-          </div>
-          {/* 테이블 행 */}
-          {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
-            <div key={i} className="grid grid-cols-6 gap-4 py-3 border-b last:border-0">
-              <Skeleton className="h-5 w-20" />
-              <Skeleton className="h-5 w-24" />
-              <Skeleton className="h-5 w-28" />
-              <Skeleton className="h-5 w-16" />
-              <Skeleton className="h-5 w-20" />
-              <Skeleton className="h-5 w-32" />
-            </div>
-          ))}
-        </CardContent>
-      </Card>
     </div>
   );
 }

--- a/src/app/(dashboard)/distributor/inventory/loading.tsx
+++ b/src/app/(dashboard)/distributor/inventory/loading.tsx
@@ -1,8 +1,9 @@
 /**
  * 유통사 재고 조회 페이지 로딩 UI
+ * 요약 + 제품별 카드 리스트 형태
  */
 import { Skeleton } from '@/components/ui/skeleton';
-import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Card, CardHeader } from '@/components/ui/card';
 
 export default function InventoryLoading(): React.ReactElement {
   return (
@@ -13,35 +14,38 @@ export default function InventoryLoading(): React.ReactElement {
         <Skeleton className="h-4 w-96" />
       </div>
 
-      {/* 재고 테이블 스켈레톤 */}
-      <Card>
-        <CardHeader>
-          <div className="flex justify-between items-center">
-            <Skeleton className="h-6 w-32" />
-            <Skeleton className="h-10 w-48" />
-          </div>
-        </CardHeader>
-        <CardContent>
-          {/* 테이블 헤더 */}
-          <div className="border-b pb-3 mb-4">
-            <div className="grid grid-cols-4 gap-4">
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-4 w-16" />
-            </div>
-          </div>
-          {/* 테이블 행 */}
-          {[1, 2, 3, 4, 5].map((i) => (
-            <div key={i} className="grid grid-cols-4 gap-4 py-3 border-b last:border-0">
-              <Skeleton className="h-5 w-32" />
-              <Skeleton className="h-5 w-20" />
-              <Skeleton className="h-5 w-28" />
-              <Skeleton className="h-5 w-16" />
-            </div>
-          ))}
-        </CardContent>
-      </Card>
+      {/* 재고 요약 */}
+      <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-5 w-5" />
+          <Skeleton className="h-5 w-20" />
+        </div>
+        <div className="text-right space-y-1">
+          <Skeleton className="h-8 w-24 ml-auto" />
+          <Skeleton className="h-4 w-12 ml-auto" />
+        </div>
+      </div>
+
+      {/* 제품별 카드 */}
+      <div className="space-y-3">
+        {[1, 2, 3, 4].map((i) => (
+          <Card key={i}>
+            <CardHeader className="cursor-pointer">
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex items-center gap-3 min-w-0 flex-1">
+                  <Skeleton className="h-6 w-6" />
+                  <Skeleton className="h-5 w-5" />
+                  <div className="space-y-1">
+                    <Skeleton className="h-5 w-40" />
+                    <Skeleton className="h-3 w-24" />
+                  </div>
+                </div>
+                <Skeleton className="h-6 w-16 rounded-full" />
+              </div>
+            </CardHeader>
+          </Card>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/app/(dashboard)/distributor/shipment-history/loading.tsx
+++ b/src/app/(dashboard)/distributor/shipment-history/loading.tsx
@@ -1,5 +1,6 @@
 /**
  * 유통사 출고 이력 페이지 로딩 UI
+ * 카드 리스트 형태 (ShipmentHistoryTable)
  */
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
@@ -13,37 +14,44 @@ export default function ShipmentHistoryLoading(): React.ReactElement {
         <Skeleton className="h-4 w-80" />
       </div>
 
-      {/* 출고 이력 테이블 스켈레톤 */}
-      <Card>
-        <CardHeader>
-          <div className="flex justify-between items-center">
-            <Skeleton className="h-6 w-28" />
-            <Skeleton className="h-10 w-32" />
-          </div>
-        </CardHeader>
-        <CardContent>
-          {/* 테이블 헤더 */}
-          <div className="border-b pb-3 mb-4">
-            <div className="grid grid-cols-5 gap-4">
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-4 w-16" />
-            </div>
-          </div>
-          {/* 테이블 행 */}
-          {[1, 2, 3, 4, 5, 6].map((i) => (
-            <div key={i} className="grid grid-cols-5 gap-4 py-3 border-b last:border-0">
-              <Skeleton className="h-5 w-28" />
-              <Skeleton className="h-5 w-24" />
-              <Skeleton className="h-5 w-16" />
-              <Skeleton className="h-5 w-32" />
-              <Skeleton className="h-8 w-16" />
-            </div>
-          ))}
-        </CardContent>
-      </Card>
+      {/* 출고 이력 카드 리스트 */}
+      <div className="space-y-4">
+        {[1, 2, 3, 4].map((i) => (
+          <Card key={i}>
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <Skeleton className="h-10 w-10 rounded-full" />
+                  <div className="space-y-1">
+                    <Skeleton className="h-5 w-32" />
+                    <Skeleton className="h-4 w-24" />
+                  </div>
+                </div>
+                <div className="text-right space-y-1">
+                  <Skeleton className="h-6 w-16 ml-auto" />
+                  <Skeleton className="h-5 w-20 rounded-full ml-auto" />
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="pt-0">
+              {/* 제품 정보 */}
+              <div className="space-y-2">
+                <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+                  <div className="flex items-center gap-2">
+                    <Skeleton className="h-4 w-4" />
+                    <Skeleton className="h-4 w-32" />
+                  </div>
+                  <Skeleton className="h-5 w-12 rounded-full" />
+                </div>
+              </div>
+              {/* 회수 버튼 영역 */}
+              <div className="mt-3 pt-3 border-t">
+                <Skeleton className="h-8 w-20" />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/app/(dashboard)/distributor/shipment/loading.tsx
+++ b/src/app/(dashboard)/distributor/shipment/loading.tsx
@@ -1,5 +1,6 @@
 /**
  * 유통사 출고 페이지 로딩 UI
+ * 3열 레이아웃: 좌측(출고대상 + 제품선택 + 수량입력), 우측(장바구니)
  */
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
@@ -9,57 +10,57 @@ export default function ShipmentLoading(): React.ReactElement {
     <div className="space-y-6">
       {/* 페이지 헤더 스켈레톤 */}
       <div className="space-y-2">
-        <Skeleton className="h-8 w-20" />
+        <Skeleton className="h-8 w-16" />
         <Skeleton className="h-4 w-96" />
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* 출고 폼 스켈레톤 */}
-        <Card>
-          <CardHeader>
-            <Skeleton className="h-6 w-32" />
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {/* 대상 조직 선택 */}
-            <div className="space-y-2">
-              <Skeleton className="h-4 w-24" />
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* 왼쪽: 출고대상 + 제품 선택 + 수량 입력 */}
+        <div className="lg:col-span-2 space-y-6">
+          {/* 출고 대상 선택 */}
+          <Card>
+            <CardHeader>
+              <Skeleton className="h-6 w-24" />
+            </CardHeader>
+            <CardContent>
               <Skeleton className="h-10 w-full" />
-            </div>
-            {/* 제품 선택 */}
-            <div className="space-y-2">
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-10 w-full" />
-            </div>
-            {/* 수량 입력 */}
-            <div className="space-y-2">
-              <Skeleton className="h-4 w-12" />
-              <Skeleton className="h-10 w-32" />
-            </div>
-            {/* 장바구니 추가 버튼 */}
-            <Skeleton className="h-10 w-full" />
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
 
-        {/* 장바구니 스켈레톤 */}
-        <Card>
-          <CardHeader>
-            <Skeleton className="h-6 w-24" />
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {[1, 2].map((i) => (
-                <div key={i} className="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
-                  <div className="space-y-1">
-                    <Skeleton className="h-5 w-32" />
+          {/* 제품 선택 */}
+          <Card>
+            <CardHeader>
+              <Skeleton className="h-6 w-24" />
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+                {[1, 2, 3, 4, 5, 6].map((i) => (
+                  <div key={i} className="border rounded-lg p-3 space-y-2">
                     <Skeleton className="h-4 w-24" />
+                    <Skeleton className="h-3 w-20" />
+                    <Skeleton className="h-3 w-16" />
                   </div>
-                  <Skeleton className="h-8 w-8" />
-                </div>
-              ))}
-            </div>
-            <Skeleton className="h-10 w-full mt-4" />
-          </CardContent>
-        </Card>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* 오른쪽: 장바구니 */}
+        <div className="lg:col-span-1">
+          <Card>
+            <CardHeader>
+              <Skeleton className="h-6 w-28" />
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="text-center py-8">
+                <Skeleton className="h-12 w-12 rounded-full mx-auto mb-3" />
+                <Skeleton className="h-4 w-32 mx-auto" />
+              </div>
+              <Skeleton className="h-10 w-full" />
+            </CardContent>
+          </Card>
+        </div>
       </div>
     </div>
   );

--- a/src/app/(dashboard)/hospital/dashboard/loading.tsx
+++ b/src/app/(dashboard)/hospital/dashboard/loading.tsx
@@ -1,5 +1,6 @@
 /**
  * 병원 대시보드 로딩 UI
+ * 환영 카드 + 3개 통계 카드 레이아웃
  */
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
@@ -7,13 +8,24 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 export default function HospitalDashboardLoading(): React.ReactElement {
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <Skeleton className="h-8 w-48" />
-        <Skeleton className="h-4 w-64" />
-      </div>
+      {/* 환영 메시지 카드 */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-4 w-64 mb-4" />
+          <div className="space-y-2">
+            <Skeleton className="h-3 w-48" />
+            <Skeleton className="h-3 w-40" />
+            <Skeleton className="h-3 w-36" />
+          </div>
+        </CardContent>
+      </Card>
 
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        {Array.from({ length: 4 }).map((_, i) => (
+      {/* 통계 카드 - 3개 (병원) */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {[1, 2, 3].map((i) => (
           <Card key={i}>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <Skeleton className="h-4 w-24" />

--- a/src/app/(dashboard)/hospital/history/loading.tsx
+++ b/src/app/(dashboard)/hospital/history/loading.tsx
@@ -1,5 +1,6 @@
 /**
  * 병원 거래 이력 페이지 로딩 UI
+ * 카드 리스트 형태 (TransactionHistoryTable)
  */
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
@@ -10,46 +11,55 @@ export default function HistoryLoading(): React.ReactElement {
       {/* 페이지 헤더 스켈레톤 */}
       <div className="space-y-2">
         <Skeleton className="h-8 w-32" />
-        <Skeleton className="h-4 w-72" />
+        <Skeleton className="h-4 w-96" />
       </div>
 
-      {/* 필터 영역 스켈레톤 */}
-      <div className="flex gap-4 flex-wrap">
-        <Skeleton className="h-10 w-32" />
-        <Skeleton className="h-10 w-40" />
-        <Skeleton className="h-10 w-36" />
+      {/* 거래 이력 카드 리스트 */}
+      <div className="space-y-4">
+        {[1, 2, 3, 4].map((i) => (
+          <Card key={i}>
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  {/* 액션 아이콘 */}
+                  <Skeleton className="h-10 w-10 rounded-full" />
+                  <div className="space-y-1">
+                    <Skeleton className="h-5 w-16 rounded-full" />
+                    <Skeleton className="h-4 w-32" />
+                  </div>
+                </div>
+                {/* 수량 */}
+                <div className="text-right space-y-1">
+                  <Skeleton className="h-6 w-16 ml-auto" />
+                  <Skeleton className="h-3 w-12 ml-auto" />
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="pt-0">
+              {/* 거래 당사자 표시 */}
+              <div className="flex items-center gap-2 mb-3 p-2 bg-gray-50 rounded-lg">
+                <Skeleton className="h-3 w-3" />
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-4 w-4" />
+                <Skeleton className="h-3 w-3" />
+                <Skeleton className="h-4 w-24" />
+              </div>
+              {/* 제품 목록 */}
+              <div className="space-y-2">
+                <div className="border rounded-lg p-3">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <Skeleton className="h-4 w-4" />
+                      <Skeleton className="h-4 w-32" />
+                    </div>
+                    <Skeleton className="h-5 w-12 rounded-full" />
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
       </div>
-
-      {/* 거래 이력 테이블 스켈레톤 */}
-      <Card>
-        <CardHeader>
-          <Skeleton className="h-6 w-28" />
-        </CardHeader>
-        <CardContent>
-          {/* 테이블 헤더 */}
-          <div className="border-b pb-3 mb-4">
-            <div className="grid grid-cols-6 gap-4">
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-4 w-24" />
-            </div>
-          </div>
-          {/* 테이블 행 */}
-          {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
-            <div key={i} className="grid grid-cols-6 gap-4 py-3 border-b last:border-0">
-              <Skeleton className="h-5 w-20" />
-              <Skeleton className="h-5 w-24" />
-              <Skeleton className="h-5 w-28" />
-              <Skeleton className="h-5 w-16" />
-              <Skeleton className="h-5 w-20" />
-              <Skeleton className="h-5 w-32" />
-            </div>
-          ))}
-        </CardContent>
-      </Card>
     </div>
   );
 }

--- a/src/app/(dashboard)/hospital/inventory/loading.tsx
+++ b/src/app/(dashboard)/hospital/inventory/loading.tsx
@@ -1,8 +1,9 @@
 /**
  * 병원 재고 조회 페이지 로딩 UI
+ * 요약 + 제품별 카드 리스트 형태
  */
 import { Skeleton } from '@/components/ui/skeleton';
-import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Card, CardHeader } from '@/components/ui/card';
 
 export default function InventoryLoading(): React.ReactElement {
   return (
@@ -13,35 +14,38 @@ export default function InventoryLoading(): React.ReactElement {
         <Skeleton className="h-4 w-96" />
       </div>
 
-      {/* 재고 테이블 스켈레톤 */}
-      <Card>
-        <CardHeader>
-          <div className="flex justify-between items-center">
-            <Skeleton className="h-6 w-32" />
-            <Skeleton className="h-10 w-48" />
-          </div>
-        </CardHeader>
-        <CardContent>
-          {/* 테이블 헤더 */}
-          <div className="border-b pb-3 mb-4">
-            <div className="grid grid-cols-4 gap-4">
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-4 w-16" />
-            </div>
-          </div>
-          {/* 테이블 행 */}
-          {[1, 2, 3, 4, 5].map((i) => (
-            <div key={i} className="grid grid-cols-4 gap-4 py-3 border-b last:border-0">
-              <Skeleton className="h-5 w-32" />
-              <Skeleton className="h-5 w-20" />
-              <Skeleton className="h-5 w-28" />
-              <Skeleton className="h-5 w-16" />
-            </div>
-          ))}
-        </CardContent>
-      </Card>
+      {/* 재고 요약 */}
+      <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-5 w-5" />
+          <Skeleton className="h-5 w-20" />
+        </div>
+        <div className="text-right space-y-1">
+          <Skeleton className="h-8 w-24 ml-auto" />
+          <Skeleton className="h-4 w-12 ml-auto" />
+        </div>
+      </div>
+
+      {/* 제품별 카드 */}
+      <div className="space-y-3">
+        {[1, 2, 3, 4].map((i) => (
+          <Card key={i}>
+            <CardHeader className="cursor-pointer">
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex items-center gap-3 min-w-0 flex-1">
+                  <Skeleton className="h-6 w-6" />
+                  <Skeleton className="h-5 w-5" />
+                  <div className="space-y-1">
+                    <Skeleton className="h-5 w-40" />
+                    <Skeleton className="h-3 w-24" />
+                  </div>
+                </div>
+                <Skeleton className="h-6 w-16 rounded-full" />
+              </div>
+            </CardHeader>
+          </Card>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/app/(dashboard)/hospital/treatment-history/loading.tsx
+++ b/src/app/(dashboard)/hospital/treatment-history/loading.tsx
@@ -1,5 +1,6 @@
 /**
  * 시술 이력 페이지 로딩 UI
+ * 카드 리스트 형태 (TreatmentHistoryTable)
  */
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
@@ -13,37 +14,49 @@ export default function TreatmentHistoryLoading(): React.ReactElement {
         <Skeleton className="h-4 w-80" />
       </div>
 
-      {/* 시술 이력 테이블 스켈레톤 */}
-      <Card>
-        <CardHeader>
-          <div className="flex justify-between items-center">
-            <Skeleton className="h-6 w-28" />
-            <Skeleton className="h-10 w-48" />
-          </div>
-        </CardHeader>
-        <CardContent>
-          {/* 테이블 헤더 */}
-          <div className="border-b pb-3 mb-4">
-            <div className="grid grid-cols-5 gap-4">
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-4 w-24" />
-            </div>
-          </div>
-          {/* 테이블 행 */}
-          {[1, 2, 3, 4, 5, 6].map((i) => (
-            <div key={i} className="grid grid-cols-5 gap-4 py-3 border-b last:border-0">
-              <Skeleton className="h-5 w-28" />
-              <Skeleton className="h-5 w-24" />
-              <Skeleton className="h-5 w-28" />
-              <Skeleton className="h-5 w-16" />
-              <Skeleton className="h-5 w-32" />
-            </div>
-          ))}
-        </CardContent>
-      </Card>
+      {/* 시술 이력 카드 리스트 */}
+      <div className="space-y-4">
+        {[1, 2, 3, 4].map((i) => (
+          <Card key={i}>
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <Skeleton className="h-10 w-10 rounded-full" />
+                  <div className="space-y-1">
+                    <Skeleton className="h-5 w-28" />
+                    <Skeleton className="h-4 w-32" />
+                  </div>
+                </div>
+                <div className="text-right space-y-1">
+                  <Skeleton className="h-6 w-16 ml-auto" />
+                  <Skeleton className="h-5 w-20 rounded-full ml-auto" />
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="pt-0">
+              {/* 환자 정보 */}
+              <div className="flex items-center gap-2 mb-3 p-2 bg-gray-50 rounded-lg">
+                <Skeleton className="h-4 w-4" />
+                <Skeleton className="h-4 w-28" />
+              </div>
+              {/* 제품 정보 */}
+              <div className="space-y-2">
+                <div className="flex items-center justify-between p-3 border rounded-lg">
+                  <div className="flex items-center gap-2">
+                    <Skeleton className="h-4 w-4" />
+                    <Skeleton className="h-4 w-32" />
+                  </div>
+                  <Skeleton className="h-5 w-12 rounded-full" />
+                </div>
+              </div>
+              {/* 회수 버튼 영역 */}
+              <div className="mt-3 pt-3 border-t">
+                <Skeleton className="h-8 w-20" />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/app/(dashboard)/hospital/treatment/loading.tsx
+++ b/src/app/(dashboard)/hospital/treatment/loading.tsx
@@ -1,5 +1,6 @@
 /**
  * 시술 등록 페이지 로딩 UI
+ * 3열 레이아웃: 좌측(환자정보 + 제품선택 + 수량입력), 우측(장바구니)
  */
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
@@ -13,37 +14,67 @@ export default function TreatmentLoading(): React.ReactElement {
         <Skeleton className="h-4 w-96" />
       </div>
 
-      {/* 시술 폼 카드 스켈레톤 */}
-      <Card>
-        <CardHeader>
-          <Skeleton className="h-6 w-40" />
-        </CardHeader>
-        <CardContent className="space-y-6">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* 왼쪽: 환자정보 + 제품 선택 */}
+        <div className="lg:col-span-2 space-y-6">
           {/* 환자 정보 */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-10 w-full" />
-            </div>
-            <div className="space-y-2">
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-10 w-full" />
-            </div>
-          </div>
+          <Card>
+            <CardHeader>
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-5 w-5" />
+                <Skeleton className="h-6 w-24" />
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Skeleton className="h-4 w-20" />
+                  <Skeleton className="h-10 w-full" />
+                  <Skeleton className="h-3 w-48" />
+                </div>
+                <div className="space-y-2">
+                  <Skeleton className="h-4 w-16" />
+                  <Skeleton className="h-10 w-full" />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
           {/* 제품 선택 */}
-          <div className="space-y-2">
-            <Skeleton className="h-4 w-20" />
-            <Skeleton className="h-10 w-full" />
-          </div>
-          {/* 수량 입력 */}
-          <div className="space-y-2">
-            <Skeleton className="h-4 w-12" />
-            <Skeleton className="h-10 w-32" />
-          </div>
-          {/* 제출 버튼 */}
-          <Skeleton className="h-10 w-32" />
-        </CardContent>
-      </Card>
+          <Card>
+            <CardHeader>
+              <Skeleton className="h-6 w-24" />
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+                {[1, 2, 3, 4, 5, 6].map((i) => (
+                  <div key={i} className="border rounded-lg p-3 space-y-2">
+                    <Skeleton className="h-4 w-24" />
+                    <Skeleton className="h-3 w-20" />
+                    <Skeleton className="h-3 w-16" />
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* 오른쪽: 장바구니 */}
+        <div className="lg:col-span-1">
+          <Card>
+            <CardHeader>
+              <Skeleton className="h-6 w-28" />
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="text-center py-8">
+                <Skeleton className="h-12 w-12 rounded-full mx-auto mb-3" />
+                <Skeleton className="h-4 w-32 mx-auto" />
+              </div>
+              <Skeleton className="h-10 w-full" />
+            </CardContent>
+          </Card>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/(dashboard)/manufacturer/history/loading.tsx
+++ b/src/app/(dashboard)/manufacturer/history/loading.tsx
@@ -1,5 +1,6 @@
 /**
  * 거래 이력 페이지 로딩 UI
+ * 카드 리스트 형태 (TransactionHistoryTable)
  */
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
@@ -10,46 +11,55 @@ export default function HistoryLoading(): React.ReactElement {
       {/* 페이지 헤더 스켈레톤 */}
       <div className="space-y-2">
         <Skeleton className="h-8 w-32" />
-        <Skeleton className="h-4 w-72" />
+        <Skeleton className="h-4 w-96" />
       </div>
 
-      {/* 필터 영역 스켈레톤 */}
-      <div className="flex gap-4 flex-wrap">
-        <Skeleton className="h-10 w-32" />
-        <Skeleton className="h-10 w-40" />
-        <Skeleton className="h-10 w-36" />
+      {/* 거래 이력 카드 리스트 */}
+      <div className="space-y-4">
+        {[1, 2, 3, 4].map((i) => (
+          <Card key={i}>
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  {/* 액션 아이콘 */}
+                  <Skeleton className="h-10 w-10 rounded-full" />
+                  <div className="space-y-1">
+                    <Skeleton className="h-5 w-16 rounded-full" />
+                    <Skeleton className="h-4 w-32" />
+                  </div>
+                </div>
+                {/* 수량 */}
+                <div className="text-right space-y-1">
+                  <Skeleton className="h-6 w-16 ml-auto" />
+                  <Skeleton className="h-3 w-12 ml-auto" />
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="pt-0">
+              {/* 거래 당사자 표시 */}
+              <div className="flex items-center gap-2 mb-3 p-2 bg-gray-50 rounded-lg">
+                <Skeleton className="h-3 w-3" />
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-4 w-4" />
+                <Skeleton className="h-3 w-3" />
+                <Skeleton className="h-4 w-24" />
+              </div>
+              {/* 제품 목록 */}
+              <div className="space-y-2">
+                <div className="border rounded-lg p-3">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <Skeleton className="h-4 w-4" />
+                      <Skeleton className="h-4 w-32" />
+                    </div>
+                    <Skeleton className="h-5 w-12 rounded-full" />
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
       </div>
-
-      {/* 거래 이력 테이블 스켈레톤 */}
-      <Card>
-        <CardHeader>
-          <Skeleton className="h-6 w-28" />
-        </CardHeader>
-        <CardContent>
-          {/* 테이블 헤더 */}
-          <div className="border-b pb-3 mb-4">
-            <div className="grid grid-cols-6 gap-4">
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-4 w-24" />
-            </div>
-          </div>
-          {/* 테이블 행 */}
-          {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
-            <div key={i} className="grid grid-cols-6 gap-4 py-3 border-b last:border-0">
-              <Skeleton className="h-5 w-20" />
-              <Skeleton className="h-5 w-24" />
-              <Skeleton className="h-5 w-28" />
-              <Skeleton className="h-5 w-16" />
-              <Skeleton className="h-5 w-20" />
-              <Skeleton className="h-5 w-32" />
-            </div>
-          ))}
-        </CardContent>
-      </Card>
     </div>
   );
 }

--- a/src/app/(dashboard)/manufacturer/inventory/loading.tsx
+++ b/src/app/(dashboard)/manufacturer/inventory/loading.tsx
@@ -1,8 +1,9 @@
 /**
  * 재고 조회 페이지 로딩 UI
+ * 요약 + 제품별 카드 리스트 형태
  */
 import { Skeleton } from '@/components/ui/skeleton';
-import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Card, CardHeader } from '@/components/ui/card';
 
 export default function InventoryLoading(): React.ReactElement {
   return (
@@ -13,35 +14,38 @@ export default function InventoryLoading(): React.ReactElement {
         <Skeleton className="h-4 w-96" />
       </div>
 
-      {/* 재고 테이블 스켈레톤 */}
-      <Card>
-        <CardHeader>
-          <div className="flex justify-between items-center">
-            <Skeleton className="h-6 w-32" />
-            <Skeleton className="h-10 w-48" />
-          </div>
-        </CardHeader>
-        <CardContent>
-          {/* 테이블 헤더 */}
-          <div className="border-b pb-3 mb-4">
-            <div className="grid grid-cols-4 gap-4">
-              <Skeleton className="h-4 w-20" />
-              <Skeleton className="h-4 w-16" />
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-4 w-16" />
-            </div>
-          </div>
-          {/* 테이블 행 */}
-          {[1, 2, 3, 4, 5].map((i) => (
-            <div key={i} className="grid grid-cols-4 gap-4 py-3 border-b last:border-0">
-              <Skeleton className="h-5 w-32" />
-              <Skeleton className="h-5 w-20" />
-              <Skeleton className="h-5 w-28" />
-              <Skeleton className="h-5 w-16" />
-            </div>
-          ))}
-        </CardContent>
-      </Card>
+      {/* 재고 요약 */}
+      <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-5 w-5" />
+          <Skeleton className="h-5 w-20" />
+        </div>
+        <div className="text-right space-y-1">
+          <Skeleton className="h-8 w-24 ml-auto" />
+          <Skeleton className="h-4 w-12 ml-auto" />
+        </div>
+      </div>
+
+      {/* 제품별 카드 */}
+      <div className="space-y-3">
+        {[1, 2, 3, 4].map((i) => (
+          <Card key={i}>
+            <CardHeader className="cursor-pointer">
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex items-center gap-3 min-w-0 flex-1">
+                  <Skeleton className="h-6 w-6" />
+                  <Skeleton className="h-5 w-5" />
+                  <div className="space-y-1">
+                    <Skeleton className="h-5 w-40" />
+                    <Skeleton className="h-3 w-24" />
+                  </div>
+                </div>
+                <Skeleton className="h-6 w-16 rounded-full" />
+              </div>
+            </CardHeader>
+          </Card>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/app/(dashboard)/manufacturer/production/loading.tsx
+++ b/src/app/(dashboard)/manufacturer/production/loading.tsx
@@ -1,5 +1,6 @@
 /**
  * 생산 등록 페이지 로딩 UI
+ * E안: 2열 레이아웃 (좌: 아코디언 제품 선택, 우: 생산 정보 폼)
  */
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
@@ -10,29 +11,74 @@ export default function ProductionLoading(): React.ReactElement {
       {/* 페이지 헤더 스켈레톤 */}
       <div className="space-y-2">
         <Skeleton className="h-8 w-32" />
-        <Skeleton className="h-4 w-72" />
+        <Skeleton className="h-4 w-96" />
       </div>
 
-      {/* 폼 카드 스켈레톤 */}
-      <Card>
-        <CardHeader>
-          <Skeleton className="h-6 w-40" />
-        </CardHeader>
-        <CardContent className="space-y-6">
-          {/* 제품 선택 */}
-          <div className="space-y-2">
-            <Skeleton className="h-4 w-16" />
-            <Skeleton className="h-10 w-full" />
-          </div>
-          {/* 수량 입력 */}
-          <div className="space-y-2">
-            <Skeleton className="h-4 w-12" />
-            <Skeleton className="h-10 w-32" />
-          </div>
-          {/* 제출 버튼 */}
-          <Skeleton className="h-10 w-24" />
-        </CardContent>
-      </Card>
+      {/* E안: 2열 레이아웃 */}
+      <div className="flex flex-col lg:flex-row gap-6">
+        {/* 좌측: 아코디언 제품 선택 영역 */}
+        <div className="flex-1 lg:max-w-[60%]">
+          <Card>
+            <CardHeader className="pb-3">
+              <Skeleton className="h-6 w-24" />
+              <Skeleton className="h-4 w-48" />
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {/* 검색 입력 */}
+              <Skeleton className="h-10 w-full" />
+
+              {/* 아코디언 그룹 */}
+              <div className="space-y-2">
+                {[1, 2, 3].map((i) => (
+                  <div key={i} className="border rounded-lg px-3 py-3">
+                    <div className="flex items-center gap-2">
+                      <Skeleton className="h-4 w-4" />
+                      <Skeleton className="h-4 w-32" />
+                      <Skeleton className="h-5 w-8 rounded-full" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* 전체 그룹 수 */}
+              <div className="text-center pt-2 border-t">
+                <Skeleton className="h-3 w-32 mx-auto" />
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* 우측: 생산 정보 폼 */}
+        <div className="lg:w-[40%]">
+          <Card>
+            <CardHeader className="pb-3">
+              <Skeleton className="h-6 w-24" />
+              <Skeleton className="h-4 w-40" />
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {/* 수량 입력 */}
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-12" />
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-3 w-48" />
+              </div>
+              {/* 생산일자 */}
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+              {/* 사용기한 */}
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-10 w-full" />
+                <Skeleton className="h-3 w-56" />
+              </div>
+              {/* 제출 버튼 */}
+              <Skeleton className="h-10 w-full" />
+            </CardContent>
+          </Card>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/(dashboard)/manufacturer/settings/loading.tsx
+++ b/src/app/(dashboard)/manufacturer/settings/loading.tsx
@@ -1,5 +1,6 @@
 /**
  * 환경 설정 페이지 로딩 UI
+ * Lot 번호 설정 폼 레이아웃
  */
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
@@ -10,25 +11,47 @@ export default function SettingsLoading(): React.ReactElement {
       {/* 페이지 헤더 스켈레톤 */}
       <div className="space-y-2">
         <Skeleton className="h-8 w-32" />
-        <Skeleton className="h-4 w-80" />
+        <Skeleton className="h-4 w-72" />
       </div>
 
-      {/* 설정 폼 카드 스켈레톤 */}
+      {/* Lot 번호 설정 카드 */}
       <Card>
         <CardHeader>
-          <Skeleton className="h-6 w-40" />
+          <Skeleton className="h-6 w-32" />
           <Skeleton className="h-4 w-72" />
         </CardHeader>
         <CardContent className="space-y-6">
-          {/* Lot 번호 접두사 */}
+          {/* 접두어 */}
           <div className="space-y-2">
-            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-16" />
             <Skeleton className="h-10 w-full max-w-md" />
+            <Skeleton className="h-3 w-64" />
           </div>
-          {/* 사용기한 설정 */}
+          {/* 모델 코드 자릿수 */}
           <div className="space-y-2">
             <Skeleton className="h-4 w-32" />
             <Skeleton className="h-10 w-32" />
+            <Skeleton className="h-3 w-48" />
+          </div>
+          {/* 날짜 형식 */}
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-10 w-full max-w-md" />
+          </div>
+          {/* Lot 번호 미리보기 */}
+          <div className="p-4 bg-gray-50 rounded-lg border">
+            <Skeleton className="h-3 w-28 mb-2" />
+            <Skeleton className="h-6 w-40" />
+            <Skeleton className="h-3 w-56 mt-2" />
+          </div>
+
+          <hr />
+
+          {/* 사용기한 */}
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-28" />
+            <Skeleton className="h-10 w-full max-w-md" />
+            <Skeleton className="h-3 w-52" />
           </div>
           {/* 저장 버튼 */}
           <Skeleton className="h-10 w-24" />

--- a/src/app/(dashboard)/manufacturer/shipment/loading.tsx
+++ b/src/app/(dashboard)/manufacturer/shipment/loading.tsx
@@ -1,6 +1,6 @@
 /**
  * 제조사 출고 페이지 로딩 UI
- * 제품 카드와 장바구니 레이아웃 유지
+ * 3열 레이아웃: 좌측(출고대상 + 제품선택 + 수량입력), 우측(장바구니)
  */
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
@@ -10,41 +10,54 @@ export default function ManufacturerShipmentLoading(): React.ReactElement {
     <div className="space-y-6">
       {/* 페이지 헤더 스켈레톤 */}
       <div className="space-y-2">
-        <Skeleton className="h-8 w-32" />
-        <Skeleton className="h-4 w-56" />
+        <Skeleton className="h-8 w-16" />
+        <Skeleton className="h-4 w-96" />
       </div>
 
-      <div className="grid gap-6 lg:grid-cols-3">
-        {/* 제품 선택 영역 */}
-        <div className="lg:col-span-2 space-y-4">
-          <Skeleton className="h-6 w-24" />
-          <div className="grid gap-4 md:grid-cols-2">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <Card key={i}>
-                <CardHeader>
-                  <Skeleton className="h-5 w-32" />
-                  <Skeleton className="h-4 w-24" />
-                </CardHeader>
-                <CardContent className="space-y-2">
-                  <Skeleton className="h-4 w-full" />
-                  <Skeleton className="h-4 w-3/4" />
-                  <Skeleton className="h-10 w-full mt-4" />
-                </CardContent>
-              </Card>
-            ))}
-          </div>
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* 왼쪽: 출고대상 + 제품 선택 + 수량 입력 */}
+        <div className="lg:col-span-2 space-y-6">
+          {/* 출고 대상 선택 */}
+          <Card>
+            <CardHeader>
+              <Skeleton className="h-6 w-24" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-10 w-full" />
+            </CardContent>
+          </Card>
+
+          {/* 제품 선택 */}
+          <Card>
+            <CardHeader>
+              <Skeleton className="h-6 w-24" />
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+                {[1, 2, 3, 4, 5, 6].map((i) => (
+                  <div key={i} className="border rounded-lg p-3 space-y-2">
+                    <Skeleton className="h-4 w-24" />
+                    <Skeleton className="h-3 w-20" />
+                    <Skeleton className="h-3 w-16" />
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
         </div>
 
-        {/* 장바구니 영역 */}
+        {/* 오른쪽: 장바구니 */}
         <div className="lg:col-span-1">
           <Card>
             <CardHeader>
-              <Skeleton className="h-6 w-20" />
+              <Skeleton className="h-6 w-28" />
             </CardHeader>
             <CardContent className="space-y-4">
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-3/4" />
-              <Skeleton className="h-10 w-full mt-4" />
+              <div className="text-center py-8">
+                <Skeleton className="h-12 w-12 rounded-full mx-auto mb-3" />
+                <Skeleton className="h-4 w-32 mx-auto" />
+              </div>
+              <Skeleton className="h-10 w-full" />
             </CardContent>
           </Card>
         </div>


### PR DESCRIPTION
- manufacturer: production(2열), inventory(요약+카드), history(카드리스트), shipment(3열), settings(Lot미리보기 추가)
- distributor: dashboard(환영카드+3통계), shipment(3열), inventory(요약+카드), history(카드리스트), shipment-history(카드리스트)
- hospital: dashboard(환영카드+3통계), treatment(3열), inventory(요약+카드), history(카드리스트), treatment-history(카드리스트)
- admin: dashboard(환영카드+4통계+2열), approvals(카드리스트), history(필터+카드리스트+페이지네이션), recalls(필터+카드리스트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)