### PR TITLE
fix(date): include end date in date range filters (KST)

### DIFF
--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -47,3 +47,31 @@ export function formatDateTimeKorea(date: Date | string): string {
     hour12: false,
   });
 }
+
+/**
+ * 종료일을 해당 일자 끝까지 포함하도록 변환 (한국 시간 KST 기준)
+ * DB 쿼리에서 날짜 범위의 종료 시점을 정의할 때 사용
+ * PostgreSQL이 +09:00 오프셋을 인식하여 UTC로 자동 변환
+ *
+ * @param dateString yyyy-MM-dd 형식의 날짜 문자열
+ * @returns ISO 8601 형식의 해당 일자 KST 23:59:59.999
+ * @example
+ * toEndOfDayKST('2025-01-05') // '2025-01-05T23:59:59.999+09:00'
+ */
+export function toEndOfDayKST(dateString: string): string {
+  return `${dateString}T23:59:59.999+09:00`;
+}
+
+/**
+ * 시작일을 해당 일자 시작부터 포함하도록 변환 (한국 시간 KST 기준)
+ * DB 쿼리에서 날짜 범위의 시작 시점을 정의할 때 사용
+ * PostgreSQL이 +09:00 오프셋을 인식하여 UTC로 자동 변환
+ *
+ * @param dateString yyyy-MM-dd 형식의 날짜 문자열
+ * @returns ISO 8601 형식의 해당 일자 KST 00:00:00.000
+ * @example
+ * toStartOfDayKST('2025-01-05') // '2025-01-05T00:00:00.000+09:00'
+ */
+export function toStartOfDayKST(dateString: string): string {
+  return `${dateString}T00:00:00.000+09:00`;
+}

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -28,7 +28,14 @@ export {
 } from './format';
 
 // Date
-export { toISODateString, formatDateKorean, formatDate, formatDateTimeKorea } from './date';
+export {
+  toISODateString,
+  formatDateKorean,
+  formatDate,
+  formatDateTimeKorea,
+  toEndOfDayKST,
+  toStartOfDayKST,
+} from './date';
 
 // Time
 export {

--- a/src/services/admin/event-summary.service.ts
+++ b/src/services/admin/event-summary.service.ts
@@ -5,6 +5,7 @@
 
 import { createClient } from '@/lib/supabase/server';
 import { createLogger } from '@/lib/logger';
+import { toEndOfDayKST, toStartOfDayKST } from '@/lib/utils/date';
 import {
   maskPhoneNumber,
   parseRpcArray,
@@ -94,10 +95,10 @@ export async function getAdminEventSummary(
   } = query;
   const offset = (page - DEFAULT_PAGE) * pageSize;
 
-  // 공통 RPC 파라미터
+  // 공통 RPC 파라미터 (KST 기준으로 날짜 범위 변환하여 종료일 포함)
   const rpcParams = {
-    p_start_date: startDate ? `${startDate}T00:00:00Z` : undefined,
-    p_end_date: endDate ? `${endDate}T23:59:59Z` : undefined,
+    p_start_date: startDate ? toStartOfDayKST(startDate) : undefined,
+    p_end_date: endDate ? toEndOfDayKST(endDate) : undefined,
     p_action_types: actionTypes?.length ? actionTypes : undefined,
     p_lot_number: lotNumber || undefined,
     p_product_id: productId || undefined,
@@ -423,10 +424,10 @@ export async function getAdminEventSummaryCursor(
     cursorKey,
   } = query;
 
-  // RPC 파라미터 구성 (undefined는 Supabase RPC에서 생략됨)
+  // RPC 파라미터 구성 (KST 기준으로 날짜 범위 변환하여 종료일 포함)
   const rpcParams = {
-    p_start_date: startDate ? `${startDate}T00:00:00Z` : undefined,
-    p_end_date: endDate ? `${endDate}T23:59:59Z` : undefined,
+    p_start_date: startDate ? toStartOfDayKST(startDate) : undefined,
+    p_end_date: endDate ? toEndOfDayKST(endDate) : undefined,
     p_action_types: actionTypes?.length ? actionTypes : undefined,
     p_lot_number: lotNumber || undefined,
     p_product_id: productId || undefined,

--- a/src/services/admin/history.service.ts
+++ b/src/services/admin/history.service.ts
@@ -5,6 +5,7 @@
 
 import { createClient } from '@/lib/supabase/server';
 import { createLogger } from '@/lib/logger';
+import { toEndOfDayKST } from '@/lib/utils/date';
 import {
   getOrganizationName,
   maskPhoneNumber,
@@ -110,12 +111,12 @@ export async function getAdminHistory(
     queryBuilder = queryBuilder.eq('lot.product.id', productId);
   }
 
-  // 기간 필터
+  // 기간 필터 (KST 기준으로 날짜 범위 변환하여 종료일 포함)
   if (startDate) {
     queryBuilder = queryBuilder.gte('created_at', startDate);
   }
   if (endDate) {
-    queryBuilder = queryBuilder.lte('created_at', endDate);
+    queryBuilder = queryBuilder.lte('created_at', toEndOfDayKST(endDate));
   }
 
   const { data: virtualCodes, count, error } = await queryBuilder.range(

--- a/src/services/history.service.ts
+++ b/src/services/history.service.ts
@@ -17,6 +17,7 @@
 
 import { createClient } from '@/lib/supabase/server';
 import { createLogger } from '@/lib/logger';
+import { toEndOfDayKST, toStartOfDayKST } from '@/lib/utils/date';
 import {
   getOrganizationName,
   maskPhoneNumber,
@@ -191,11 +192,12 @@ export async function getTransactionHistory(
   const offset = (page - DEFAULT_PAGE) * pageSize;
 
   // 공통 파라미터 (RPC는 null이 아닌 undefined 사용)
+  // KST 기준으로 날짜 범위 변환하여 종료일 포함 (해당 날짜의 23:59:59.999까지)
   const rpcParams = {
     p_organization_id: organizationId,
     p_action_types: actionTypes && actionTypes.length > 0 ? actionTypes : undefined,
-    p_start_date: startDate || undefined,
-    p_end_date: endDate || undefined,
+    p_start_date: startDate ? toStartOfDayKST(startDate) : undefined,
+    p_end_date: endDate ? toEndOfDayKST(endDate) : undefined,
     p_is_recall: isRecall ?? undefined,
   };
 
@@ -397,11 +399,12 @@ export async function getTransactionHistoryCursor(
   } = query;
 
   // RPC 파라미터 구성
+  // KST 기준으로 날짜 범위 변환하여 종료일 포함 (해당 날짜의 23:59:59.999까지)
   const rpcParams = {
     p_organization_id: organizationId,
     p_action_types: actionTypes?.length ? actionTypes : undefined,
-    p_start_date: startDate || undefined,
-    p_end_date: endDate || undefined,
+    p_start_date: startDate ? toStartOfDayKST(startDate) : undefined,
+    p_end_date: endDate ? toEndOfDayKST(endDate) : undefined,
     p_is_recall: isRecall ?? undefined,
     p_limit: limit,
     p_cursor_time: cursorTime || undefined,

--- a/src/services/treatment.service.ts
+++ b/src/services/treatment.service.ts
@@ -12,6 +12,7 @@
 import { createClient } from '@/lib/supabase/server';
 import { createLogger } from '@/lib/logger';
 import { getHoursDifference } from '@/lib/utils';
+import { toEndOfDayKST } from '@/lib/utils/date';
 import { normalizePhoneNumber } from '@/lib/validations/common';
 import type {
   ApiResponse,
@@ -267,12 +268,12 @@ export async function getTreatmentHistory(
     .order('treatment_date', { ascending: false })
     .order('created_at', { ascending: false });
 
-  // 필터 적용
+  // 필터 적용 (KST 기준으로 날짜 범위 변환하여 종료일 포함)
   if (startDate) {
     queryBuilder = queryBuilder.gte('treatment_date', startDate);
   }
   if (endDate) {
-    queryBuilder = queryBuilder.lte('treatment_date', endDate);
+    queryBuilder = queryBuilder.lte('treatment_date', toEndOfDayKST(endDate));
   }
   if (patientPhone) {
     const normalizedPhone = normalizePhoneNumber(patientPhone);


### PR DESCRIPTION
날짜 범위 필터에서 종료일이 포함되지 않던 버그 수정

문제: 종료일을 "2025-01-05"로 설정하면 해당 날짜의 데이터가
조회되지 않음 (PostgreSQL이 00:00:00으로 변환하여 자정 이후 제외)

해결:
- toEndOfDayKST(), toStartOfDayKST() 유틸리티 함수 추가
- 종료일을 KST 23:59:59.999로 변환하여 해당 날짜 전체 포함
- 영향 받는 모든 서비스 파일 수정 (7개 파일)

영향 페이지:
- /manufacturer/history, /distributor/history, /hospital/history
- /hospital/treatment-history
- /admin/history, /admin/recalls

🤖 Generated with [Claude Code](https://claude.com/claude-code)