### PR TITLE
fix: add production URL to logout CSRF whitelist

### DIFF
--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -17,6 +17,7 @@ function isValidOrigin(request: NextRequest): boolean {
   // 허용된 origins 목록
   const allowedOrigins = [
     process.env.NEXT_PUBLIC_APP_URL,
+    'https://neo-certify-20251205.vercel.app',
     'http://localhost:3000',
     'http://127.0.0.1:3000',
   ].filter(Boolean) as string[];


### PR DESCRIPTION
## Summary
- 프로덕션 환경에서 로그아웃 시 "Invalid request origin" 오류 수정
- CSRF 보호 화이트리스트에 프로덕션 URL 추가

## Changes
- `src/app/api/auth/logout/route.ts`: 프로덕션 URL을 allowedOrigins에 추가

## Test plan
- [x] 로컬 환경 로그아웃 테스트
- [ ] 프로덕션 환경 로그아웃 테스트 (배포 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)