### PR TITLE
feat: 회원가입 이메일 인증 UX 개선

### DIFF
--- a/src/app/(auth)/register/verify-email/page.tsx
+++ b/src/app/(auth)/register/verify-email/page.tsx
@@ -1,0 +1,14 @@
+import { VerifyEmailNotice } from '@/components/forms/VerifyEmailNotice';
+
+export const metadata = {
+  title: '이메일 인증 | 네오인증서',
+  description: '이메일 인증 안내',
+};
+
+/**
+ * 이메일 인증 안내 페이지
+ * 회원가입 완료 후 리다이렉트되는 페이지
+ */
+export default function VerifyEmailPage(): React.ReactElement {
+  return <VerifyEmailNotice />;
+}

--- a/src/components/forms/VerifyEmailNotice.tsx
+++ b/src/components/forms/VerifyEmailNotice.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+/**
+ * 이메일 인증 안내 컴포넌트
+ * 회원가입 완료 후 이메일 인증을 안내하고 재발송 기능을 제공합니다.
+ */
+
+import { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { Mail, RefreshCw } from 'lucide-react';
+
+import { resendVerificationAction } from '@/app/(auth)/actions';
+import { Button } from '@/components/ui/button';
+
+export function VerifyEmailNotice(): React.ReactElement {
+  const searchParams = useSearchParams();
+  const email = searchParams.get('email') || '';
+  const [isResending, setIsResending] = useState(false);
+  const [resendMessage, setResendMessage] = useState<string | null>(null);
+  const [resendError, setResendError] = useState<string | null>(null);
+
+  async function handleResend() {
+    if (!email || isResending) return;
+
+    setIsResending(true);
+    setResendMessage(null);
+    setResendError(null);
+
+    try {
+      const result = await resendVerificationAction(email);
+      if (result.success) {
+        setResendMessage('인증 메일을 재발송했습니다. 메일함을 확인해주세요.');
+      } else {
+        setResendError(result.error?.message || '재발송에 실패했습니다.');
+      }
+    } catch {
+      setResendError('서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setIsResending(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center">
+        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-blue-100">
+          <Mail className="h-8 w-8 text-blue-600" />
+        </div>
+        <h2 className="text-2xl font-semibold text-gray-900">이메일 인증</h2>
+        <p className="mt-2 text-sm text-gray-600">
+          가입하신 이메일로 인증 메일을 보냈습니다.
+          <br />
+          메일함을 확인해주세요.
+        </p>
+        {email && (
+          <p className="mt-2 text-sm font-medium text-gray-800">{email}</p>
+        )}
+      </div>
+
+      {resendMessage && (
+        <div className="p-3 rounded-md bg-green-50 text-green-700 text-sm">
+          {resendMessage}
+        </div>
+      )}
+
+      {resendError && (
+        <div className="p-3 rounded-md bg-red-50 text-red-700 text-sm">
+          {resendError}
+        </div>
+      )}
+
+      <div className="space-y-3">
+        <Button
+          variant="outline"
+          className="w-full"
+          onClick={handleResend}
+          disabled={isResending || !email}
+        >
+          <RefreshCw className={`mr-2 h-4 w-4 ${isResending ? 'animate-spin' : ''}`} />
+          {isResending ? '발송 중…' : '인증 메일 재발송'}
+        </Button>
+
+        <div className="text-center text-sm">
+          <Link href="/login" className="text-primary hover:underline font-medium">
+            로그인 페이지로 이동
+          </Link>
+        </div>
+      </div>
+
+      <div className="rounded-md bg-gray-50 p-4 text-xs text-gray-500 space-y-1">
+        <p>• 메일이 도착하지 않으면 스팸함을 확인해주세요.</p>
+        <p>• 인증 메일은 발송 후 24시간 동안 유효합니다.</p>
+        <p>• 이메일 인증 완료 후 로그인할 수 있습니다.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -7,6 +7,9 @@ export const ERROR_MESSAGES = {
   // 인증
   AUTH: {
     LOGIN_FAILED: '이메일 또는 비밀번호가 올바르지 않습니다.',
+    EMAIL_NOT_CONFIRMED: '이메일 인증이 완료되지 않았습니다. 메일함을 확인해주세요.',
+    VERIFICATION_EMAIL_SENT: '인증 메일을 발송했습니다. 메일함을 확인해주세요.',
+    VERIFICATION_EMAIL_RESEND_FAILED: '인증 메일 재발송에 실패했습니다. 잠시 후 다시 시도해주세요.',
     UNAUTHORIZED: '해당 기능에 대한 접근 권한이 없습니다.',
     SESSION_EXPIRED: '세션이 만료되었습니다. 다시 로그인해주세요.',
     INVALID_EMAIL: '올바른 이메일 형식이 아닙니다.',

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -8,12 +8,12 @@ import type { OrganizationType } from './organization';
 /**
  * 공개 라우트 (인증 불필요)
  */
-export const PUBLIC_ROUTES = ['/login', '/register', '/forgot-password', '/reset-password', '/find-account', '/mock'] as const;
+export const PUBLIC_ROUTES = ['/login', '/register', '/register/verify-email', '/forgot-password', '/reset-password', '/find-account', '/mock'] as const;
 
 /**
  * 인증 라우트 (로그인된 사용자는 대시보드로 리다이렉트)
  */
-export const AUTH_ROUTES = ['/login', '/register', '/forgot-password', '/find-account'] as const;
+export const AUTH_ROUTES = ['/login', '/register', '/register/verify-email', '/forgot-password', '/find-account'] as const;
 
 /**
  * 보호된 라우트 (조직 유형별)
@@ -39,6 +39,11 @@ export const DEFAULT_REDIRECT: Record<OrganizationType, string> = {
  * 로그인 페이지 경로
  */
 export const LOGIN_PATH = '/login';
+
+/**
+ * 이메일 인증 안내 페이지 경로
+ */
+export const VERIFY_EMAIL_PATH = '/register/verify-email';
 
 /**
  * 승인 대기 페이지 경로


### PR DESCRIPTION
## 변경 사항

### 이메일 인증 안내 페이지 (/register/verify-email)
- 회원가입 완료 후 이메일 인증 안내 페이지로 이동
- 가입 이메일 표시 + 인증 메일 재발송 버튼
- 로그인 페이지 이동 링크

### 로그인 시 미인증 에러 분기
- 이메일 미인증 상태 로그인 시 명확한 안내 메시지 표시
- "이메일 인증이 완료되지 않았습니다. 메일함을 확인해주세요."
- 인증 메일 재발송 버튼 제공

### 인증 메일 재발송
- resendVerificationAction Server Action 추가
- Supabase resend API 활용
- Rate limiting 적용

### 변경 파일 (7개)
- 신규: verify-email 페이지, VerifyEmailNotice 컴포넌트
- 수정: auth.service, actions, LoginForm, messages, routes