### PR TITLE
feat: 알림톡 테스트 페이지 비밀번호 보호 및 프로덕션 접근 허용

### DIFF
--- a/docs/TEST_GUIDE.md
+++ b/docs/TEST_GUIDE.md
@@ -1,0 +1,366 @@
+# 테스트 가이드
+
+> **목적**: 테스트 계정 정보, 전체 페이지 구조, 테스트 시나리오 안내
+
+---
+
+## 테스트 계정
+
+### 기본 테스트 계정
+
+| 역할 | 이메일 | 비밀번호 | 조직명 | 상태 |
+|------|--------|----------|--------|------|
+| 관리자 | `admin@neocert.com` | `admin123` | 네오인증서 관리자 | ACTIVE |
+| 제조사 | `manufacturer@neocert.com` | `test123` | 테스트제조사 | ACTIVE |
+| 유통사 | `distributor@neocert.com` | `test123` | 테스트유통사 | ACTIVE |
+| 병원 | `hospital@neocert.com` | `test123` | 테스트병원 | ACTIVE |
+
+### 추가 테스트 계정
+
+| 역할 | 이메일 | 비밀번호 | 조직명 | 상태 | 용도 |
+|------|--------|----------|--------|------|------|
+| 유통사 | `distributor2@neocert.com` | `test123` | 테스트유통사2 | ACTIVE | 다단계 유통 테스트 |
+| 병원 | `hospital2@neocert.com` | `test123` | 테스트병원2 | ACTIVE | 복수 병원 테스트 |
+| 병원 | `pending@neocert.com` | `test123` | 승인대기병원 | PENDING_APPROVAL | 승인 플로우 테스트 |
+
+### 조직 ID 참조
+
+| 조직 | UUID |
+|------|------|
+| 관리자 | `a0000000-0000-0000-0000-000000000001` |
+| 제조사 | `a0000000-0000-0000-0000-000000000002` |
+| 유통사1 | `a0000000-0000-0000-0000-000000000003` |
+| 병원1 | `a0000000-0000-0000-0000-000000000004` |
+| 유통사2 | `a0000000-0000-0000-0000-000000000005` |
+| 병원2 | `a0000000-0000-0000-0000-000000000006` |
+| 승인대기 | `a0000000-0000-0000-0000-000000000007` |
+
+---
+
+## 전체 페이지 구조
+
+### 공개 페이지 (인증 불필요)
+
+| 경로 | 페이지명 | 설명 | UI 접근 |
+|------|----------|------|---------|
+| `/` | 홈 | 랜딩 페이지, 로그인 페이지로 리다이렉트 | 직접 URL |
+| `/login` | 로그인 | 이메일/비밀번호 로그인 | 직접 URL |
+| `/register` | 회원가입 | 조직 등록 신청 | 로그인 페이지 링크 |
+| `/mock/kakao` | 카카오 알림톡 Mock | 알림톡 미리보기 (개발용) | **직접 URL만** |
+
+### 제조사 페이지 (`manufacturer@neocert.com`)
+
+| 경로 | 페이지명 | 설명 | UI 접근 |
+|------|----------|------|---------|
+| `/manufacturer/dashboard` | 대시보드 | 통계 요약, 최근 활동 | 사이드바 메뉴 |
+| `/manufacturer/products` | 제품 관리 | 제품 등록/수정/삭제 | 사이드바 메뉴 |
+| `/manufacturer/production` | 생산 등록 | Lot 생산, 가상코드 생성 | 사이드바 메뉴 |
+| `/manufacturer/shipment` | 출고 | 유통사/병원으로 출고 | 사이드바 메뉴 |
+| `/manufacturer/inventory` | 재고 조회 | 보유 재고 현황 | 사이드바 메뉴 |
+| `/manufacturer/history` | 거래 이력 | 전체 거래 히스토리, 회수 기능 | 사이드바 메뉴 |
+| `/manufacturer/inbox` | 수신함 | 알림 메시지 | 사이드바 메뉴 |
+| `/manufacturer/settings` | 환경 설정 | Lot 번호 형식 설정 | 사이드바 메뉴 |
+
+### 유통사 페이지 (`distributor@neocert.com`)
+
+| 경로 | 페이지명 | 설명 | UI 접근 |
+|------|----------|------|---------|
+| `/distributor/dashboard` | 대시보드 | 통계 요약, 최근 활동 | 사이드바 메뉴 |
+| `/distributor/shipment` | 출고 | 병원/다른 유통사로 출고 | 사이드바 메뉴 |
+| `/distributor/inventory` | 재고 조회 | 보유 재고 현황 | 사이드바 메뉴 |
+| `/distributor/history` | 거래 이력 | 전체 거래 히스토리, 회수 기능 | 사이드바 메뉴 |
+
+### 병원 페이지 (`hospital@neocert.com`)
+
+| 경로 | 페이지명 | 설명 | UI 접근 |
+|------|----------|------|---------|
+| `/hospital/dashboard` | 대시보드 | 통계 요약, 최근 활동 | 사이드바 메뉴 |
+| `/hospital/treatment` | 시술 등록 | 환자 시술 기록 | 사이드바 메뉴 |
+| `/hospital/treatment-history` | 시술 이력 | 시술 내역, 회수 기능 | 사이드바 메뉴 |
+| `/hospital/disposal` | 폐기 등록 | 재고 폐기 처리 | 사이드바 메뉴 |
+| `/hospital/inventory` | 재고 조회 | 보유 재고 현황 | 사이드바 메뉴 |
+| `/hospital/history` | 거래 이력 | 전체 거래 히스토리 | 사이드바 메뉴 |
+| `/hospital/settings` | 환경 설정 | 병원 설정 | 사이드바 메뉴 |
+
+### 관리자 페이지 (`admin@neocert.com`)
+
+| 경로 | 페이지명 | 설명 | UI 접근 |
+|------|----------|------|---------|
+| `/admin/dashboard` | 대시보드 | 전체 시스템 통계 | 사이드바 메뉴 |
+| `/admin/organizations` | 조직 관리 | 조직 목록, 상태 관리 | 사이드바 메뉴 |
+| `/admin/approvals` | 가입 승인 | 대기 중인 가입 신청 처리 | 사이드바 메뉴 |
+| `/admin/history` | 전체 이력 | 시스템 전체 이벤트 조회 | 사이드바 메뉴 |
+| `/admin/recalls` | 회수 이력 | 회수 발생 모니터링 | 사이드바 메뉴 |
+| `/admin/alerts` | 알림 관리 | 시스템 알림 설정 | 사이드바 메뉴 |
+| `/admin/inbox` | 수신함 | 알림 메시지 | 사이드바 메뉴 |
+| `/admin/db-explorer` | DB 탐색기 | 데이터 조회 (개발용) | **직접 URL만** |
+
+---
+
+## UI에서 직접 접근 불가능한 페이지
+
+다음 페이지들은 **네비게이션 메뉴에 없으며** 직접 URL 입력으로만 접근 가능합니다:
+
+| 경로 | 설명 | 접근 계정 |
+|------|------|----------|
+| `/` | 홈 (리다이렉트) | 모든 사용자 |
+| `/mock/kakao` | 카카오 알림톡 Mock | 인증 불필요 |
+| `/alimtalk-test` | 알림톡 발송 테스트 | 비밀번호 보호 (아래 참조) |
+| `/admin/db-explorer` | DB 탐색기 (개발용) | 관리자 |
+
+### 디자인 시스템 페이지 (개발용)
+
+화면 설계 문서화를 위한 디자인 시스템 페이지입니다:
+
+| 경로 | 설명 | 용도 |
+|------|------|------|
+| `/design-system` | 디자인 시스템 인덱스 | 역할별 페이지맵 링크 |
+| `/design-system/admin` | 관리자 페이지맵 | 관리자 화면 구조 시각화 |
+| `/design-system/manufacturer` | 제조사 페이지맵 | 제조사 화면 구조 시각화 |
+| `/design-system/distributor` | 유통사 페이지맵 | 유통사 화면 구조 시각화 |
+| `/design-system/hospital` | 병원 페이지맵 | 병원 화면 구조 시각화 |
+
+### 정품 인증 페이지
+
+| 경로 | 설명 | 용도 |
+|------|------|------|
+| `/verify/[treatmentId]` | 정품 인증 확인 | 카카오 알림톡 링크로 접근, 시술 정보 표시 |
+| `/inquiry` | 문의하기 | 정품 인증 문의 폼 |
+
+### 샘플 페이지 (개발용)
+
+UI 패턴 비교 및 프로토타입 검토를 위한 샘플 페이지입니다:
+
+| 경로 | 설명 | 용도 |
+|------|------|------|
+| `/sample/mobile-nav` | 모바일 네비게이션 샘플 인덱스 | 3가지 패턴 비교 |
+| `/sample/mobile-nav/bottom-nav` | Bottom Navigation 패턴 | 하단 고정 네비게이션 바 |
+| `/sample/mobile-nav/hamburger` | Hamburger Menu 패턴 | 전체 화면 메뉴 |
+| `/sample/mobile-nav/top-tabs` | Top Tabs 패턴 | 상단 탭 네비게이션 |
+| `/sample/admin-history-detail` | 관리자 이력 상세 UI 패턴 | 5가지 Lot 상세 뷰 옵션 비교 |
+| `/sample/history-scroll-comparison` | 이력 테이블 반응형 비교 | 가로스크롤/반응형 페이지네이션 비교 |
+| `/sample/org-history-detail` | 조직 거래이력 상세보기 | 제품 코드 목록 표시 UI 테스트 |
+| `/sample/production-selector` | 생산 등록 제품 선택 UI 패턴 | 4가지 UX 개선 옵션 비교 |
+
+---
+
+## 배포 환경 URL
+
+- **Production**: `https://neo-certify-20251205.vercel.app`
+- **로컬 개발**: `http://localhost:3000`
+
+### 배포 환경 전체 페이지 URL
+
+```
+# 공개 페이지
+https://neo-certify-20251205.vercel.app/
+https://neo-certify-20251205.vercel.app/login
+https://neo-certify-20251205.vercel.app/register
+https://neo-certify-20251205.vercel.app/mock/kakao
+
+# 디자인 시스템 페이지
+https://neo-certify-20251205.vercel.app/design-system
+https://neo-certify-20251205.vercel.app/design-system/admin
+https://neo-certify-20251205.vercel.app/design-system/manufacturer
+https://neo-certify-20251205.vercel.app/design-system/distributor
+https://neo-certify-20251205.vercel.app/design-system/hospital
+
+# 정품 인증 페이지
+https://neo-certify-20251205.vercel.app/verify/[treatmentId]
+https://neo-certify-20251205.vercel.app/inquiry
+
+# 샘플 페이지 (개발용)
+https://neo-certify-20251205.vercel.app/sample/mobile-nav
+https://neo-certify-20251205.vercel.app/sample/mobile-nav/bottom-nav
+https://neo-certify-20251205.vercel.app/sample/mobile-nav/hamburger
+https://neo-certify-20251205.vercel.app/sample/mobile-nav/top-tabs
+https://neo-certify-20251205.vercel.app/sample/admin-history-detail
+https://neo-certify-20251205.vercel.app/sample/history-scroll-comparison
+https://neo-certify-20251205.vercel.app/sample/org-history-detail
+https://neo-certify-20251205.vercel.app/sample/production-selector
+
+# 제조사
+https://neo-certify-20251205.vercel.app/manufacturer/dashboard
+https://neo-certify-20251205.vercel.app/manufacturer/products
+https://neo-certify-20251205.vercel.app/manufacturer/production
+https://neo-certify-20251205.vercel.app/manufacturer/shipment
+https://neo-certify-20251205.vercel.app/manufacturer/inventory
+https://neo-certify-20251205.vercel.app/manufacturer/history
+https://neo-certify-20251205.vercel.app/manufacturer/inbox
+https://neo-certify-20251205.vercel.app/manufacturer/settings
+
+# 유통사
+https://neo-certify-20251205.vercel.app/distributor/dashboard
+https://neo-certify-20251205.vercel.app/distributor/shipment
+https://neo-certify-20251205.vercel.app/distributor/inventory
+https://neo-certify-20251205.vercel.app/distributor/history
+
+# 병원
+https://neo-certify-20251205.vercel.app/hospital/dashboard
+https://neo-certify-20251205.vercel.app/hospital/treatment
+https://neo-certify-20251205.vercel.app/hospital/treatment-history
+https://neo-certify-20251205.vercel.app/hospital/disposal
+https://neo-certify-20251205.vercel.app/hospital/inventory
+https://neo-certify-20251205.vercel.app/hospital/history
+https://neo-certify-20251205.vercel.app/hospital/settings
+
+# 관리자
+https://neo-certify-20251205.vercel.app/admin/dashboard
+https://neo-certify-20251205.vercel.app/admin/organizations
+https://neo-certify-20251205.vercel.app/admin/approvals
+https://neo-certify-20251205.vercel.app/admin/history
+https://neo-certify-20251205.vercel.app/admin/recalls
+https://neo-certify-20251205.vercel.app/admin/alerts
+https://neo-certify-20251205.vercel.app/admin/inbox
+https://neo-certify-20251205.vercel.app/admin/db-explorer
+```
+
+---
+
+## 테스트 시나리오
+
+### 1. 전체 유통 흐름 테스트
+
+1. **제조사 로그인** (`manufacturer@neocert.com`)
+   - `/manufacturer/products` → 제품 등록
+   - `/manufacturer/production` → Lot 생산 (가상코드 생성)
+   - `/manufacturer/shipment` → 유통사로 출고
+
+2. **유통사 로그인** (`distributor@neocert.com`)
+   - `/distributor/inventory` → 재고 확인
+   - `/distributor/shipment` → 병원으로 출고
+
+3. **병원 로그인** (`hospital@neocert.com`)
+   - `/hospital/inventory` → 재고 확인
+   - `/hospital/treatment` → 시술 등록 (환자 연락처 입력)
+   - `/mock/kakao` → 알림톡 메시지 확인
+
+4. **각 대시보드에서 통계 확인**
+
+### 2. 회수 테스트
+
+1. 출고 또는 시술 완료 후 **24시간 이내**
+2. 해당 이력 페이지에서 **회수 버튼** 클릭
+3. 회수 사유 입력
+4. 재고 복귀 확인
+5. `/admin/recalls`에서 회수 이력 확인
+
+### 3. 승인 플로우 테스트
+
+1. `/register`에서 새 계정 등록 (또는 `pending@neocert.com` 사용)
+2. 로그인 시도 → "승인 대기" 메시지 확인
+3. **관리자 로그인** (`admin@neocert.com`)
+4. `/admin/approvals` → 승인 처리
+5. 해당 계정으로 다시 로그인 → 대시보드 접근 확인
+
+### 4. 카카오 알림톡 확인
+
+1. 병원 계정으로 시술 등록
+2. `/mock/kakao` 페이지 접속
+3. 정품 인증 메시지 확인
+
+### 5. 알림톡 발송 테스트 (실제 API)
+
+> **주의**: 실제 API 호출로 요금이 발생합니다.
+
+#### 환경 변수 설정
+
+Vercel 환경 변수에 비밀번호를 설정해야 합니다:
+
+```
+ALIMTALK_TEST_PASSWORD=원하는비밀번호
+```
+
+#### 접근 방법
+
+1. **병원 시술 등록 화면에서 접근**
+   - `/hospital/treatment` 페이지 하단의 "알림톡 발송 테스트" 버튼 클릭
+   - 새 창으로 `/alimtalk-test` 페이지 열림
+
+2. **직접 URL 접근**
+   - `https://neo-certify-20251205.vercel.app/alimtalk-test`
+
+3. **비밀번호 입력**
+   - 페이지 접속 시 비밀번호 입력 화면 표시
+   - 올바른 비밀번호 입력 시 테스트 페이지 접근
+   - 세션 동안 인증 상태 유지
+
+#### 주요 기능
+
+- 템플릿 선택 및 변수 실시간 편집
+- 카카오톡 스타일 메시지 미리보기
+- 다중 수신자 동적 관리 (1~10명)
+- Mock/Real 모드 전환
+
+#### 테스트 완료 후 삭제 목록
+
+정식 서비스 배포 시 삭제할 항목:
+- `/src/app/alimtalk-test/` 폴더 전체
+- `/src/components/forms/TreatmentForm.tsx`의 "알림톡 발송 테스트" 버튼
+- Vercel 환경 변수 `ALIMTALK_TEST_PASSWORD`
+
+### 6. 폐기 테스트
+
+1. **병원 로그인** (`hospital@neocert.com`)
+2. `/hospital/inventory` → 재고 확인
+3. `/hospital/disposal` → 폐기 등록
+   - 제품 선택
+   - 수량 입력
+   - 폐기 사유 선택 (파손, 유효기간 만료, 기타 등)
+4. 폐기 완료 후 `/hospital/inventory`에서 재고 감소 확인
+5. `/hospital/history`에서 폐기 이력 확인
+
+---
+
+## 로컬 개발 환경 설정
+
+### 1. Supabase 로컬 서버 시작
+
+```bash
+npx supabase start
+```
+
+### 2. 데이터베이스 초기화
+
+```bash
+npx supabase db reset
+npm run gen:types
+```
+
+### 3. Next.js 개발 서버 시작
+
+```bash
+npm run dev
+```
+
+---
+
+## 문제 해결
+
+### "이메일 또는 비밀번호가 올바르지 않습니다"
+
+- Supabase Auth에 사용자가 등록되지 않음
+- Cloud 환경: 테스트 계정 Auth 사용자 생성 필요
+
+### "승인 대기 중입니다"
+
+- 조직 상태가 `PENDING_APPROVAL`
+- 관리자 계정으로 승인 필요
+
+### 대시보드 통계가 0으로 표시됨
+
+- 데이터가 없는 상태
+- 제조사에서 제품 등록 → 생산 → 출고 순서로 데이터 생성 필요
+
+### 페이지 접근 권한 오류
+
+- 각 역할별 페이지는 해당 조직 유형만 접근 가능
+- 다른 유형의 페이지 접근 시 리다이렉트됨
+
+---
+
+## 관련 문서
+
+- [개발 계획서](./DEVELOPMENT_PLAN.md)
+- [PRD 문서](./core-planning-document/neo-cert-prd-2.1.md)
+- [E2E 테스트 가이드](./E2E_TESTING_GUIDE.md)

--- a/src/app/alimtalk-test/actions.ts
+++ b/src/app/alimtalk-test/actions.ts
@@ -2,6 +2,32 @@
 
 import { sendAlimtalkBulk, type AligoButton } from '@/services/alimtalk.service';
 
+/**
+ * 알림톡 테스트 페이지 비밀번호 검증
+ * ALIMTALK_TEST_PASSWORD 환경 변수와 비교
+ */
+export async function verifyTestPasswordAction(
+  password: string
+): Promise<{ success: boolean; error?: string }> {
+  const correctPassword = process.env.ALIMTALK_TEST_PASSWORD;
+
+  if (!correctPassword) {
+    return {
+      success: false,
+      error: '테스트 비밀번호가 설정되지 않았습니다. 관리자에게 문의하세요.',
+    };
+  }
+
+  if (password !== correctPassword) {
+    return {
+      success: false,
+      error: '비밀번호가 올바르지 않습니다.',
+    };
+  }
+
+  return { success: true };
+}
+
 interface BulkSendParams {
   templateCode: string;
   message: string;
@@ -27,19 +53,11 @@ interface BulkSendResult {
 
 /**
  * 알림톡 다중 발송 Server Action
- * 개발/테스트 환경에서 실제 알림톡 발송 테스트용
+ * 비밀번호 검증 후 사용 가능 (클라이언트에서 세션 체크)
  */
 export async function sendBulkAlimtalkAction(
   params: BulkSendParams
 ): Promise<BulkSendResult> {
-  // 프로덕션 환경 체크 (명시적 허용이 없으면 차단)
-  if (
-    process.env.NODE_ENV === 'production' &&
-    process.env.ALLOW_TEST_SEND !== 'true'
-  ) {
-    throw new Error('테스트 발송은 개발 환경에서만 사용 가능합니다.');
-  }
-
   // 각 수신자에게 동일한 메시지 적용
   const result = await sendAlimtalkBulk({
     templateCode: params.templateCode,

--- a/src/app/alimtalk-test/page.tsx
+++ b/src/app/alimtalk-test/page.tsx
@@ -14,13 +14,17 @@ interface AlimtalkTestSendPageProps {
 
 /**
  * 알림톡 발송 테스트 페이지
- * 개발/테스트 환경에서 실제 알림톡 API 발송을 테스트하기 위한 페이지
+ * 비밀번호로 보호된 알림톡 API 발송 테스트 페이지
  *
  * 주요 기능:
  * - 템플릿 선택 및 변수 실시간 편집
  * - 카카오톡 스타일 메시지 미리보기
  * - 다중 수신자 동적 관리 (1~10명)
  * - Mock/Real 모드 지원 (ALIGO_TEST_MODE 환경변수)
+ *
+ * 접근 제어:
+ * - ALIMTALK_TEST_PASSWORD 환경 변수로 비밀번호 설정
+ * - 세션 스토리지에 인증 상태 저장 (브라우저 세션 동안 유효)
  *
  * URL 파라미터:
  * - template: 초기 선택할 템플릿 코드 (기본값: CERT_COMPLETE)
@@ -29,40 +33,6 @@ interface AlimtalkTestSendPageProps {
 export default async function AlimtalkTestSendPage({
   searchParams,
 }: AlimtalkTestSendPageProps): Promise<React.ReactElement> {
-  // 프로덕션 환경 접근 제어
-  if (
-    process.env.NODE_ENV === 'production' &&
-    process.env.ALLOW_TEST_SEND !== 'true'
-  ) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50">
-        <div className="rounded-lg bg-white p-8 text-center shadow-lg">
-          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
-            <svg
-              className="h-6 w-6 text-red-600"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-              />
-            </svg>
-          </div>
-          <h1 className="mb-2 text-xl font-semibold text-gray-900">
-            접근이 제한되었습니다
-          </h1>
-          <p className="text-gray-600">
-            이 페이지는 개발 환경에서만 사용 가능합니다.
-          </p>
-        </div>
-      </div>
-    );
-  }
-
   const { template, phone } = await searchParams;
 
   return <AlimtalkTestSendClient initialTemplate={template} initialPhone={phone} />;

--- a/src/components/forms/TreatmentForm.tsx
+++ b/src/components/forms/TreatmentForm.tsx
@@ -383,29 +383,27 @@ export function TreatmentForm({
                 시술 등록 시 환자에게 정품 인증 알림이 발송됩니다.
                 오류 시 24시간 이내에 회수할 수 있습니다.
               </p>
-              {/* 개발 환경에서만 표시되는 알림톡 발송 테스트 버튼 */}
-              {process.env.NODE_ENV !== 'production' && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="mt-3 w-full text-xs border-blue-300 text-blue-700 hover:bg-blue-100"
-                  onClick={() => {
-                    const params = new URLSearchParams({
-                      template: 'CERT_COMPLETE',
-                      phone: phoneInputValue || '',
-                    });
-                    window.open(
-                      `/alimtalk-test?${params}`,
-                      'alimtalk-test',
-                      'width=1680,height=950,noopener'
-                    );
-                  }}
-                >
-                  <ExternalLink className="mr-1.5 h-3 w-3" />
-                  [DEV] 알림톡 발송 테스트
-                </Button>
-              )}
+              {/* 알림톡 발송 테스트 버튼 (비밀번호 보호) */}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-3 w-full text-xs border-blue-300 text-blue-700 hover:bg-blue-100"
+                onClick={() => {
+                  const params = new URLSearchParams({
+                    template: 'CERT_COMPLETE',
+                    phone: phoneInputValue || '',
+                  });
+                  window.open(
+                    `/alimtalk-test?${params}`,
+                    'alimtalk-test',
+                    'width=1680,height=950,noopener'
+                  );
+                }}
+              >
+                <ExternalLink className="mr-1.5 h-3 w-3" />
+                알림톡 발송 테스트
+              </Button>
             </div>
           )}
         </div>


### PR DESCRIPTION
- verifyTestPasswordAction 추가 (ALIMTALK_TEST_PASSWORD 환경 변수)
- client.tsx에 비밀번호 입력 화면 추가 (sessionStorage로 세션 유지)
- page.tsx에서 기존 프로덕션 접근 제어 제거
- TreatmentForm에서 NODE_ENV 조건 제거하여 프로덕션에서도 버튼 표시
- TEST_GUIDE.md에 알림톡 테스트 페이지 문서 추가