### PR TITLE
fix: Redis mock constructor + is_recall_allowed SECURITY DEFINER (#48, #46)

### DIFF
--- a/supabase/migrations/20260212000003_fix_is_recall_allowed_security.sql
+++ b/supabase/migrations/20260212000003_fix_is_recall_allowed_security.sql
@@ -1,0 +1,37 @@
+-- ============================================================================
+-- Issue #46: is_recall_allowed SECURITY DEFINER 미설정 수정
+--
+-- 기존: SECURITY INVOKER (기본값) — RLS에 의해 접근 제한 가능
+-- 변경: SECURITY DEFINER + SET search_path = public
+--       (다른 atomic 함수들과 일관성 확보)
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION "public"."is_recall_allowed"("p_shipment_batch_id" "uuid")
+RETURNS boolean
+LANGUAGE "plpgsql"
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_shipment_date TIMESTAMPTZ;
+  v_is_recalled BOOLEAN;
+BEGIN
+  SELECT shipment_date, is_recalled
+  INTO v_shipment_date, v_is_recalled
+  FROM shipment_batches
+  WHERE id = p_shipment_batch_id;
+
+  IF NOT FOUND THEN
+    RETURN FALSE;
+  END IF;
+
+  IF v_is_recalled THEN
+    RETURN FALSE;
+  END IF;
+
+  RETURN (NOW() - v_shipment_date) <= INTERVAL '24 hours';
+END;
+$$;
+
+COMMENT ON FUNCTION "public"."is_recall_allowed"(UUID)
+    IS '시술 회수 가능 여부 확인 (24시간 이내, SECURITY DEFINER)';

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -23,11 +23,14 @@ vi.mock('@upstash/ratelimit', () => {
   return { Ratelimit: MockRatelimit };
 });
 
-vi.mock('@upstash/redis', () => ({
-  Redis: {
-    fromEnv: () => ({}),
-  },
-}));
+vi.mock('@upstash/redis', () => {
+  class MockRedis {
+    static fromEnv() {
+      return new MockRedis();
+    }
+  }
+  return { Redis: MockRedis };
+});
 
 // 모킹 후 임포트
 import {


### PR DESCRIPTION
## Summary
- **#48**: `rate-limit.test.ts` Redis mock을 plain object에서 class로 변경하여 `TypeError: Redis is not a constructor` 해결
- **#46**: `is_recall_allowed` 함수에 `SECURITY DEFINER` + `SET search_path = public` 추가 (다른 atomic 함수들과 일관성 확보)

## Changes
| File | Change |
|------|--------|
| `tests/unit/rate-limit.test.ts` | Redis mock을 class로 변경 |
| `supabase/migrations/20260212000003_fix_is_recall_allowed_security.sql` | 신규 마이그레이션 |

## Test plan
- [x] `npx vitest run tests/unit/rate-limit.test.ts` 통과
- [x] `npm run test:run` 전체 테스트 통과
- [x] `npm run type-check` 타입 체크 통과
- [x] `supabase db reset` 마이그레이션 적용 확인

Closes #48
Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)